### PR TITLE
security: force-resolve ip-address to 10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "sockjs/uuid": "^11.1.1",
     "svgo": "^4.0.1",
     "flatted": "^3.4.2",
-    "ip-address": "^10.1.1",
+    "ip-address": "^10.4.0",
     "@hono/node-server": "^1.19.13",
     "picomatch": "2.3.2",
     "tinyglobby/picomatch": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8308,10 +8308,10 @@ invert-kv@^3.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-3.0.1.tgz#a93c7a3d4386a1dc8325b97da9bb1620c0282523"
   integrity sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==
 
-ip-address@10.0.1, ip-address@^10.0.1, ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+ip-address@10.0.1, ip-address@^10.0.1, ip-address@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.4.0.tgz#c5910bc541b6eae287765d1e4846be0308a05d93"
+  integrity sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
Fixes 3 open Dependabot alerts by adding a yarn resolutions entry
that collapses two pinned ranges (exact 10.0.1 via express-rate-limit,
^10.0.1 via socks) onto the single patched 10.4.0.

- Fixes #701 (GHSA-mwp4-54f8-5fhr)
- Fixes #697 (GHSA-4xrf-jv44-h6hh)
- Fixes #696 (GHSA-22jq-vg5j-6vgg)

## Test plan
- [x] `yarn install` succeeds, single ip-address@10.4.0 entry in yarn.lock
- [x] `npm run lint` — same pre-existing errors/warnings as master, no new ones