### PR TITLE
security: update js-yaml and brace-expansion to patched versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4762,9 +4762,9 @@ bootstrap@4.4.1:
   integrity sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -4784,9 +4784,9 @@ brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -9273,17 +9273,17 @@ jose@^6.1.3:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Fixes 4 open Dependabot alerts.

- js-yaml 3.14.2 -> 3.15.1 (via @istanbuljs/load-nyc-config)
  Fixes #683 (GHSA-52cp-r559-cp3m, patched 3.15.0) and also happens to
  satisfy the older #647 (GHSA-h67p-54hq-rp68, patched 3.15.0).
- js-yaml 4.1.1 -> 4.3.1 (via cosmiconfig)
  Fixes #684 (GHSA-52cp-r559-cp3m, patched 4.3.0) and also happens to
  satisfy the older #646 (GHSA-h67p-54hq-rp68, patched 4.2.0).
  Both existing semver ranges (^3.13.1 / ^4.1.0) already permitted
  these versions; hand-edited the lockfile's resolved version/integrity
  to the real npm registry values rather than adding a resolutions
  entry, since no forcing was needed.
- brace-expansion 1.1.15 -> 1.1.16 (^1.1.7 range, transitive via
  generator-jhipster's minimatch tree)
  Fixes #686 (GHSA-3jxr-9vmj-r5cp, patched 1.1.16).
- brace-expansion 5.0.6 -> 5.0.7 (^5.0.5 range)
  Fixes #651 (GHSA-3jxr-9vmj-r5cp, patched 5.0.7). Missed in the first
  pass of this PR; caught during re-review after a full `--paginate`
  scan of all 69 open alerts turned up this older one.
  (brace-expansion 2.x ranges in the tree, ^2.0.1 -> 2.1.1 and
  ^2.0.2 -> 2.0.2, are not currently flagged by any open Dependabot
  alert and were left alone to keep this change scoped.)

## Test plan
- [x] `yarn install --check-files` completes clean
- [x] node_modules confirmed at patched versions for all four targets
  (js-yaml 4.3.1 top-level, js-yaml 3.15.1 nested under
  load-nyc-config, brace-expansion 1.1.16, brace-expansion 5.0.7)
- [x] `yarn why brace-expansion` / `yarn why js-yaml` show the full
  consumer chains
- [x] `npm run lint`: 0 errors / 101 warnings, same as clean master
- [x] Cross-checked the full open-alert list via
  `gh api .../dependabot/alerts --paginate` (69 total open across the
  repo) to confirm no other brace-expansion/js-yaml alert was missed